### PR TITLE
German context fixed and 'Home' translated

### DIFF
--- a/src/src.js
+++ b/src/src.js
@@ -140,7 +140,7 @@ const SVG = document.getElementById("S"),
               },
             },
             {
-              text: () => _("Home"),
+              text: () => "Home",
               action: () => {
                 if (state.inventory.includes("Silk")) {
                   fly("Home");


### PR DESCRIPTION
- German words are now correct regarding context.
- The choice "Home" is now translatable