### PR TITLE
Moving cursor instead of auto next text bubble

### DIFF
--- a/index.html
+++ b/index.html
@@ -1236,6 +1236,24 @@
     <div id="B">
       <div id="BM"></div>
       <div id="BP"></div>
+      <svg
+        id="cursor"
+        width="12.238086"
+        height="11.985301"
+        viewBox="0 0 3.2379935 3.1711108"
+      >
+        <path
+          style="
+            fill: #ffffff;
+            fill-opacity: 1;
+            stroke: #000000;
+            stroke-width: 0.462903;
+            stroke-dasharray: none;
+            stroke-opacity: 1;
+          "
+          d="M 0.21962203,0.24056797 H 2.9947125 V 1.6974991 L 1.6071672,2.876505 0.21962203,1.6974991 Z"
+        />
+      </svg>
     </div>
     <div id="I"></div>
     <div id="M"></div>

--- a/src/main.css
+++ b/src/main.css
@@ -59,3 +59,19 @@ a {
   top: 0;
   padding: 45vh 0 0;
 }
+#cursor {
+  animation: MoveUpDown 1.3s linear infinite;
+  position: absolute;
+  display: inline-block;
+  padding-left: 2px;
+  right: -5px;
+}
+@keyframes MoveUpDown {
+  0%,
+  100% {
+    bottom: 10%;
+  }
+  50% {
+    bottom: 30%;
+  }
+}

--- a/src/src.js
+++ b/src/src.js
@@ -47,6 +47,7 @@ const SVG = document.getElementById("S"),
   BM = document.getElementById("BM"),
   I = document.getElementById("I"),
   BP = document.getElementById("BP"),
+  CURSOR = document.getElementById("cursor"),
   items = {
     Silk: document.getElementById("Silk"),
     Helmet: document.getElementById("Helmet"),
@@ -1073,6 +1074,8 @@ function say(a, f, cont) {
     });
     BM.appendChild(ol);
     B.next = null;
+    // do not show cursor for choices
+    CURSOR.style.display = "none";
   } else {
     BM.innerText = _(what);
     B.talking = a.length > 0 || f != null ? 1 : 0;
@@ -1087,7 +1090,7 @@ function say(a, f, cont) {
         f && f();
       }
     };
-    B.tid = setTimeout(B.next, 1000 + 200 * what.split(" ").length);
+    CURSOR.style.display = "block";
   }
   const whoRect = who.getBoundingClientRect(),
     whoRectHalfWidth = (whoRect.width / 2) | 0,
@@ -1187,6 +1190,8 @@ function resize() {
   style.transformOrigin = "top left";
   style.transform = `scale(${ratio})`;
   style.display = "block";
+
+  CURSOR.style.transform = `scale(${ratio / 4})`;
 
   show(state.scene);
 }


### PR DESCRIPTION
Some text bubbles could not be read because they were disappearing to fast. It is not easy to adjust them correctly.
So here is a suggestion taken from old GameBoy RPGs were a cursor is moving up and down indicating that you have to tap for the next text bubble.